### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/Filter/keywords.txt
+++ b/Filter/keywords.txt
@@ -6,19 +6,19 @@
 # Datatypes,classes (KEYWORD1)
 ##############################################
 
-Filter  KEYWORD1
-iirFilter  KEYWORD1
-firFilter  KEYWORD1
-newFilter  KEYWORD1
+Filter	KEYWORD1
+iirFilter	KEYWORD1
+firFilter	KEYWORD1
+newFilter	KEYWORD1
 
 ##############################################
 # Methods and Functions (KEYWORD2)
 ##############################################
 
-begin KEYWORD2
-setFilter KEYWORD2
-setOrder  KEYWORD2
-run KEYWORD2
+begin	KEYWORD2
+setFilter	KEYWORD2
+setOrder	KEYWORD2
+run	KEYWORD2
 
 ##############################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords